### PR TITLE
Privatize change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,16 @@ This is a lists changes in the history of Portainer Templates. This document sho
 
 ### 1.1.1
 
-* Correct missing non-root templates
+* clean up
 
 ### 1.1.0
 
-* Add non-root support for VXS
-* Add PTP-Snooping support or VXS
-* Add non-root support for Forza
 * Update environment variables for Forza
-* Add PDMX to internal-templates-v2.json
-* Correct NDI issue in Altus
-* Add Infinity Link to internal-templates-v2.json
-* Correct Zephyr Connect to be functional
+* Correct NDI issue in Altusl
 * Correct Coturn template
-* Remove Coturn and Beacon from templates-v2.json
-* Add Vero to internal templates
 * Add Dual macvlan support for the following products
   * Altus
   * VXS
-  * Zephyr Connect
   * Forza
 * Update README.md to further explain templates and compose files further
 * Create this change log


### PR DESCRIPTION
We need to remove items that are in development changelog that should not be published. 